### PR TITLE
Make initial sync task streaming and bug fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM semtech/mu-javascript-template:1.5.0-beta.2
+FROM semtech/mu-javascript-template:1.5.0-beta.4
 LABEL maintainer="Redpencil <info@redpencil.io>"

--- a/lib/initial-sync/dump-file.js
+++ b/lib/initial-sync/dump-file.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import fetch from 'node-fetch';
-import { Parser, Writer } from 'n3';
+import { StreamParser, StreamWriter, Writer } from 'n3';
 
 import {
   SYNC_BASE_URL,
@@ -45,30 +45,22 @@ class DumpFile {
     }
   }
 
-  async load() {
+  async loadTripleStream() {
     try {
       await this.download();
-      const data = fs.readFileSync(this.filePath, 'utf8');
-      const triples = await this.convertToNtriplesStringArray(data);
+      const stream = fs.createReadStream(this.filePath, 'utf8');
+      const streamparser = new StreamParser();
+      const streamwriter = new StreamWriter({ format: 'N-Triples' });
+      stream.pipe(streamparser);
+      streamparser.pipe(streamwriter);
       console.log(`Successfully loaded file ${this.id} stored at ${this.filePath}`);
-      return triples;
+      return streamwriter;
     }
     catch(error){
       console.log(`Something went wrong while ingesting file ${this.id} stored at ${this.filePath}`);
       console.log(error);
       throw error;
     }
-  }
-
-  //Helper function to parse TTL file.
-  async convertToNtriplesStringArray(data){
-    const parser = new Parser();
-    const quads = parser.parse(data);
-    const triples = [];
-    for(const quad of quads){
-      triples.push(await this.quadToNTripleString(quad));
-    }
-    return triples;
   }
 
   async quadToNTripleString(quad){

--- a/lib/initial-sync/initial-sync-task.js
+++ b/lib/initial-sync/initial-sync-task.js
@@ -1,6 +1,7 @@
 import { updateSudo as update } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeDateTime, sparqlEscapeUri, sparqlEscapeString, uuid } from 'mu';
 
+
 import {
   INGEST_GRAPH,
   BATCH_SIZE,
@@ -56,7 +57,7 @@ class InitialSyncTask {
     try {
       if (this.dumpFile) {
         await this.updateStatus(STATUS_BUSY);
-        const triples = await this.dumpFile.load();
+        const triples = await this.dumpFile.loadTripleStream();
         const endpoint = BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES ? DIRECT_DATABASE_ENDPOINT : process.env.MU_SPARQL_ENDPOINT;
 
         if(BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES){
@@ -178,28 +179,38 @@ async function scheduleTask(jobUri, taskOperationUri, taskIndex = "0"){
   });
 }
 
-async function insertTriples(triples, extraHeaders, endpoint, sleep = 1000) {
-  for (let i = 0; i < triples.length; i += BATCH_SIZE) {
-    console.log(`Inserting triples in batch: ${i}-${i + BATCH_SIZE}`);
+async function insertTriples(tripleStream, extraHeaders, endpoint) {
+  let batch = [];
 
-    const batch = triples.slice(i, i + BATCH_SIZE).join('\n');
+  tripleStream.on('data', async (quad) => {
+    batch.push(quad);
 
-    const insertCall = async () => {
-      await update(`
-        INSERT DATA {
-          GRAPH <${INGEST_GRAPH}> {
-            ${batch}
-          }
+    if (batch.length >= BATCH_SIZE) {
+      console.log(`Inserting batch of triples`);
+
+      await insertBatch(batch, extraHeaders, endpoint);
+    }
+  });
+
+  tripleStream.on('end', () => {
+    if (batch.length > 0) {
+      insertBatch(batch, extraHeaders, endpoint);
+    }
+  });
+}
+
+async function insertBatch(batch, extraHeaders, endpoint) {
+  const insertCall = async () => {
+    await update(`
+      INSERT DATA {
+      GRAPH <${INGEST_GRAPH}> {
+          ${batch}
         }
-      `, extraHeaders, endpoint);
-    };
+      }
+    `, extraHeaders, endpoint);
+  };
 
-    await dbOperationWithRetry(insertCall);
-
-    console.log(`Sleeping before next query execution: ${sleep}`);
-    await new Promise(r => setTimeout(r, sleep));
-  }
-
+  await dbOperationWithRetry(insertCall);
 }
 
 async function dbOperationWithRetry(callback,

--- a/lib/initial-sync/initial-sync-task.js
+++ b/lib/initial-sync/initial-sync-task.js
@@ -57,7 +57,6 @@ class InitialSyncTask {
     try {
       if (this.dumpFile) {
         await this.updateStatus(STATUS_BUSY);
-        const triples = await this.dumpFile.loadTripleStream();
         const endpoint = BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES ? DIRECT_DATABASE_ENDPOINT : process.env.MU_SPARQL_ENDPOINT;
 
         if(BYPASS_MU_AUTH_FOR_EXPENSIVE_QUERIES){
@@ -65,7 +64,7 @@ class InitialSyncTask {
         }
         console.log(`Using ${endpoint} to insert triples`);
 
-        await insertTriples(triples, { 'mu-call-scope-id': MU_CALL_SCOPE_ID_INITIAL_SYNC }, endpoint);
+        await insertTriples(await this.dumpFile.loadTripleStream(), { 'mu-call-scope-id': MU_CALL_SCOPE_ID_INITIAL_SYNC }, endpoint);
         await this.updateStatus(STATUS_SUCCESS);
       }
       else {
@@ -186,15 +185,18 @@ async function insertTriples(tripleStream, extraHeaders, endpoint) {
     batch.push(quad);
 
     if (batch.length >= BATCH_SIZE) {
-      console.log(`Inserting batch of triples`);
+      console.log(`Inserting batch of ${batch.length} triples`);
+      let oldBatch = batch;
+      batch = [];
 
-      await insertBatch(batch, extraHeaders, endpoint);
+      await insertBatch(oldBatch, extraHeaders, endpoint);
     }
   });
 
   tripleStream.on('end', () => {
     if (batch.length > 0) {
       insertBatch(batch, extraHeaders, endpoint);
+      batch = [];
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "homepage": "https://github.com/lblod/delta-consumer-single-graph-maintainer#readme",
   "dependencies": {
-    "@lblod/mu-auth-sudo": "git://github.com:lblod/mu-auth-sudo.git#bdbd063dc8e4d3a891c713a0077a54bc8a010ca1",
+    "@lblod/mu-auth-sudo": "^0.5.1",
     "cron": "^1.8.2",
     "fs-extra": "^9.0.1",
-    "node-fetch": "^2.6.1",
-    "n3": "^1.11.1"
+    "n3": "^1.11.1",
+    "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
The initial sync task has large files that cannot be read into a JavaScript string, as JavaScript only supports strings up to ~512 MB. This reads the files as a stream and processes them as batches.

Besides this, I had to fix some bugs to make it run:

- updated `mu-javascript-template` to `1.5.0-beta.4`
- un-pin `@lblod/mu-auth-sudo` as that syntax is no longer supported by npm
- add a .dockerignore to not push `node_modules` and let the template install the correct dependencies